### PR TITLE
Fix Stack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ git clone https://github.com/NorfairKing/smos
 
 ### Building with Stack
 
-Use [Stack](haskellstack.org) to install Smos with the default configuration:
+Use [Stack](https://docs.haskellstack.org/en/stable/README/) to install Smos with the default configuration:
 
 ```
 $ stack install :smos


### PR DESCRIPTION
Without the `https://` in the beginning, Github turns urls into relative links inside the Github project, for some reason. Instead of going to the indented `haskellstack.org`, it goes to `https://github.com/NorfairKing/smos/blob/master/haskellstack.org`.

Replace with a version of the URL that includes `https://`. Also use the canonical URL, to avoid a redirect.