### PR TITLE
Add ❯  character for the cursor

### DIFF
--- a/smos/src/Smos/Draw.hs
+++ b/smos/src/Smos/Draw.hs
@@ -471,7 +471,7 @@ drawEntryCursor s tc edc e = do
         concat
           [ [ case s of
                 NotSelected -> str "-"
-                MaybeSelected -> withAttr selectedAttr $ str ">"
+                MaybeSelected -> withAttr selectedAttr $ str "❯"
             ]
           , maybeToList (entryCursorStateHistoryCursor >>= drawCurrentStateFromCursor)
           , [drawHeaderCursor (selectWhen HeaderSelected) entryCursorHeaderCursor]


### PR DESCRIPTION
There is not much to describe here, except that the character being used for the cursor is "fatter" and hence more noticeable.
![2020-02-19-165745_860x54_scrot](https://user-images.githubusercontent.com/922486/74830367-fe6c3600-5338-11ea-82a3-d0ab4455ffa9.png)
