### PR TITLE
WIP: improves documentations: added skeleton for concepts and config reference

### DIFF
--- a/smos-docs-site/.gitignore
+++ b/smos-docs-site/.gitignore
@@ -3,3 +3,4 @@ _cache/
 _site/
 smos-docs-site.cabal
 *~
+_generated/

--- a/smos-docs-site/package.yaml
+++ b/smos-docs-site/package.yaml
@@ -13,6 +13,9 @@ library:
   - base >= 4.7 && < 5
   - hakyll
   - hakyll-sass
+  - smos
+  - text
+  - directory
 
 executables:
   smos-docs-site:

--- a/smos-docs-site/pages/concepts.markdown
+++ b/smos-docs-site/pages/concepts.markdown
@@ -1,0 +1,70 @@
+---
+title: SMOS Concepts
+date: 2020-04-08
+---
+
+GTD
+: GTD is a time management method by David Allen (see [Getting This
+  Done](https://en.wikipedia.org/wiki/Getting_Things_Done) on
+  Wikipedia).
+  SMOS is supposed to be a tool to implement GTD.
+
+
+<!-- the next concepts are related to SMOS configuration, but AFAIK
+are not explained -->
+
+Workflow
+: What's the meaning in SMOS and why the need for a directory?
+
+
+Projects
+: Whats the meaning in SMOS?  Why the need for a directory in the
+  configuration file?
+
+
+Archive:
+: When task and projects are completed, they are archived (i.e. moved
+  in the archive directory).
+
+State File
+: ???
+
+Entry
+: In SMOS each entry can be in one of the following states: <!-- not true. an entry can have no state -->
+
+	- WAITING
+	- TODO
+	- STARTED
+	- READY
+	- NEXT
+	- FAILED
+	- DONE
+	- CANCELLED
+
+
+Forest
+: In SMOS each forest can be in one of the following states: <!-- not true, a forest can have no state  -->
+
+	- WAITING
+	- TODO
+	- STARTED
+	- READY
+	- NEXT
+	- FAILED
+	- DONE
+	- CANCELLED
+
+
+Tag
+: It is possible to attach a tag to each entry or forest.  Predefined
+  tags are: `code`, `external`, `home`, `offline`, `online`, `power`,
+  `toast` and `work`.  It is possible to define new tags simply with
+  the [entrySelectTags](/configuration-reference.html#entrySelectTags)
+  command
+
+
+Property
+: It is possible to attach a property with a value to entries or
+  forests.  Predefined properties are: `brainpower`, `client`,
+  `timewindow`.  It is not possible to define new properties. <!--
+  Why? -->

--- a/smos-docs-site/pages/concepts.markdown
+++ b/smos-docs-site/pages/concepts.markdown
@@ -7,27 +7,38 @@ GTD
 : GTD is a time management method by David Allen (see [Getting This
   Done](https://en.wikipedia.org/wiki/Getting_Things_Done) on
   Wikipedia).
-  SMOS is supposed to be a tool to implement GTD.
+
+  SMOS is a personal management tool inspired by GTD.
 
 
 <!-- the next concepts are related to SMOS configuration, but AFAIK
 are not explained -->
 
-Workflow
-: What's the meaning in SMOS and why the need for a directory?
+Workflow Directory
+: SMOS files can be everywhere on your disk, however the `smos-query`
+  command, used to generate reports and gather informations, will
+  consult only the *workflow* directory.  The defalt value is
+  `~/workflow` however the value can be changed to better suite your
+  needs using the configuration file (see te [Configuration
+  reference](/configuration-reference.html)).
 
 
-Projects
-: Whats the meaning in SMOS?  Why the need for a directory in the
-  configuration file?
+Projects Directory
+: The *project* directory is by used the `smos-query projects` command
+  to retrieve information about your projects.  The default value is
+  `~/workflow/projects` (see the [Configuration
+  reference](/configuration-reference.html) for customization).
 
 
-Archive:
-: When task and projects are completed, they are archived (i.e. moved
-  in the archive directory).
+Archive Directory
+: When task and projects are completed, they are archived, moved in
+  the *archive* directory, so that they can be ignored by the
+  `smos-query` command.  The default value is `~/workflow/archive`
+  (see the [Configuration reference](/configuration-reference.html)
+  for customization).
 
-State File
-: ???
+<!-- State File -->
+<!-- : ??? -->
 
 Entry
 : In SMOS each entry can be in one of the following states: <!-- not true. an entry can have no state -->
@@ -41,19 +52,8 @@ Entry
 	- DONE
 	- CANCELLED
 
-
-Forest
-: In SMOS each forest can be in one of the following states: <!-- not true, a forest can have no state  -->
-
-	- WAITING
-	- TODO
-	- STARTED
-	- READY
-	- NEXT
-	- FAILED
-	- DONE
-	- CANCELLED
-
+<!-- TODO: document the order of the states.  The first state should
+be TODO or WAITING.  What the difference between READY and NEXT? -->
 
 Tag
 : It is possible to attach a tag to each entry or forest.  Predefined

--- a/smos-docs-site/pages/configuration-reference.markdown
+++ b/smos-docs-site/pages/configuration-reference.markdown
@@ -3,7 +3,7 @@ title: Customisation Reference
 date: 2020-04-07
 ---
 
-# Misc #
+## Misc ##
 
 contexts
 
@@ -13,7 +13,7 @@ work-filter
 
 : ???
 
-# Customizing directories #
+## Customizing directories ##
 
 archive-dir
 
@@ -32,11 +32,11 @@ archived-projects-dir
 : the archive projects directory
 
 
-# Customising keybindings #
+## Defining reports ##
 
-<!-- NOTE: It should be nice to be able to generate the reference for
-           the keybingings automatically, since the information are
-           already present in the help screen -->
+<!-- TODO:  -->
+
+## Customising keybindings ##
 
 Keybindings in smos are context sensitive.
 
@@ -50,40 +50,71 @@ keys:
           key: <Esc>
 ```
 
+The syntax for *special* keys follows (the meaning of each should be obvious):
+
+- \<tab\>
+- \<space>
+- \<UpRight>
+- \<UpLeft>
+- \<Up>
+- \<Right>
+- \<PrtScr>
+- \<Pause>
+- \<PageUp>
+- \<PageDown>
+- \<Menu>
+- \<Left>
+- \<Ins>
+- \<Home>
+- \<Esc>
+- \<Enter>
+- \<End>
+- \<DownRight>
+- \<DownLeft>
+- \<Down>
+- \<Del>
+- \<Center>
+- \<Begin>
+- \<BackTab>
+- \<BS>
+- \<F0> .. \<F9>
+
+The full list of available commands can be found in [the Command
+Reference](/commands.html).
+
 The following paragraph lists the valid contexts and the valid
 keybindings.
 
-## reports ##
+### reports ###
 
 In the `reports` context there is only one subcontext: `next-action`.
 
-### reports/next-action ###
+#### reports/next-action ####
 
-## help ##
+### help ###
 
 In the `help` context there are two subcontexts: `help` and `search`.
 
-### help/help ###
+#### help/help ####
 
-### help/search ###
+#### help/search ####
 
-## file ##
+### file ###
 
-### file/empty ###
+#### file/empty ####
 
-### file/logbook ###
+#### file/logbook ####
 
-### file/entry ###
+#### file/entry ####
 
-### file/header ###
+#### file/header ####
 
-### file/timestamps ###
+#### file/timestamps ####
 
-### file/state-history ###
+#### file/state-history ####
 
-### file/any ###
+#### file/any ####
 
-### file/tags ###
+#### file/tags ####
 
-### file/properties ###
-
+#### file/properties ####

--- a/smos-docs-site/pages/configuration-reference.markdown
+++ b/smos-docs-site/pages/configuration-reference.markdown
@@ -1,0 +1,89 @@
+---
+title: Customisation Reference
+date: 2020-04-07
+---
+
+# Misc #
+
+contexts
+
+: ???
+
+work-filter
+
+: ???
+
+# Customizing directories #
+
+archive-dir
+
+: the archive directory
+
+workflow-dir
+
+: the workflow directory
+
+projects-dir
+
+: the projects directory
+
+archived-projects-dir
+
+: the archive projects directory
+
+
+# Customising keybindings #
+
+<!-- NOTE: It should be nice to be able to generate the reference for
+           the keybingings automatically, since the information are
+           already present in the help screen -->
+
+Keybindings in smos are context sensitive.
+
+The generic syntax for keybindings is:
+
+```yaml
+keys:
+    context:
+        subcontext:
+        - action: actionName
+          key: <Esc>
+```
+
+The following paragraph lists the valid contexts and the valid
+keybindings.
+
+## reports ##
+
+In the `reports` context there is only one subcontext: `next-action`.
+
+### reports/next-action ###
+
+## help ##
+
+In the `help` context there are two subcontexts: `help` and `search`.
+
+### help/help ###
+
+### help/search ###
+
+## file ##
+
+### file/empty ###
+
+### file/logbook ###
+
+### file/entry ###
+
+### file/header ###
+
+### file/timestamps ###
+
+### file/state-history ###
+
+### file/any ###
+
+### file/tags ###
+
+### file/properties ###
+

--- a/smos-docs-site/src/Smos/Docs/Site.hs
+++ b/smos-docs-site/src/Smos/Docs/Site.hs
@@ -5,11 +5,22 @@ module Smos.Docs.Site
   )
 where
 
-import Hakyll
-import Hakyll.Web.Sass
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import           Hakyll
+import           Hakyll.Web.Sass
+import           Smos.Actions
+import           Smos.Default
+import           Smos.Keys
+import           Smos.Types
+import           System.Directory
+import           System.IO
 
 smosDocsSite :: IO ()
-smosDocsSite =
+smosDocsSite = do
+  createDirectoryIfMissing True "_generated"
+  generateKeybindingDocs "Help"
   hakyll $ do
     match "assets/*" $ do
       route idRoute
@@ -19,6 +30,12 @@ smosDocsSite =
       compile (sassCompilerWith sassDefConfig {sassIncludePaths = Just ["_sass"]})
     match "pages/*" $ do
       route $ composeRoutes (gsubRoute "pages/" (const "")) (setExtension "html")
+      compile $
+        pandocCompiler >>= loadAndApplyTemplate "templates/page.html" pageCtx
+          >>= loadAndApplyTemplate "templates/default.html" pageCtx
+          >>= relativizeUrls
+    match "_generated/*" $ do
+      route $ composeRoutes (gsubRoute "_generated/" (const "")) (setExtension "html")
       compile $
         pandocCompiler >>= loadAndApplyTemplate "templates/page.html" pageCtx
           >>= loadAndApplyTemplate "templates/default.html" pageCtx
@@ -37,3 +54,31 @@ smosDocsSite =
 
 pageCtx :: Context String
 pageCtx = defaultContext
+
+
+renderKeyMapping :: KeyMapping -> (Text, Text, Text)
+renderKeyMapping keyMapping =
+  case keyMapping of
+    (MapVtyExactly kp act) -> (renderKeyPress kp, actionNameText $ actionName act, actionDescription act)
+    (MapAnyTypeableChar au) -> ("??", actionNameText $ actionUsingName au, actionUsingDescription au)
+    (MapCatchAll act) -> ("any char", actionNameText $ actionName act, actionDescription act)
+    (MapCombination kp km) ->
+      let (kp', cmd, desc) =  renderKeyMapping km
+      in (renderKeyPress kp <> kp', cmd, desc)
+
+generateKeybindingDocs :: Text -> IO ()
+generateKeybindingDocs label =
+  withFile "_generated/keybindings.markdown" WriteMode $ \h -> do
+  T.hPutStrLn h "---"
+  T.hPutStrLn h "title: Key Bindings"
+  T.hPutStrLn h "---"
+  T.hPutStrLn h ""
+  T.hPutStrLn h $ "## " <> label
+  T.hPutStrLn h "Key | Command | Description"
+  T.hPutStrLn h "---:+:-------:+:-----------:"
+  forM_ (keyMapHelpMatchers $ configKeyMap defaultConfig) $ \keyMapping ->
+      T.hPutStrLn h $ renderRow $ renderKeyMapping keyMapping
+
+  where
+    renderRow :: (Text, Text, Text) -> Text
+    renderRow (kb, cmd, desc) = (T.pack $ escapeHtml $ T.unpack kb) <> " | " <> cmd <> " | " <> desc

--- a/smos-docs-site/templates/header.html
+++ b/smos-docs-site/templates/header.html
@@ -24,6 +24,8 @@
           <li><a href="/customisation-default.html">Customisation</a></li>
           <li><a href="/customisation-haskell.html">Customisation in Haskell</a></li>
 	  <li><a href="/configuration-reference.html">Configuration reference</a></li>
+	  <li><a href="/commands.html">Commands reference</a></li>
+	  <li><a href="/keybindings.html">Key Bindings</a></li>
           <li><a href="/synchronisation.html">Synchronisation</a></li>
           <li><a href="/blogposts.html">Featured blogposts</a></li>
           <hr>

--- a/smos-docs-site/templates/header.html
+++ b/smos-docs-site/templates/header.html
@@ -19,9 +19,11 @@
         <ul class="page-link">
           <li><a href="/features.html">Features</a></li>
           <li><a href="/building-installation.html">Building/Installation</a></li>
+	  <li><a href="/concepts.html">Concepts</a></li>
           <li><a href="/smos-query.html">Using smos-query</a></li>
           <li><a href="/customisation-default.html">Customisation</a></li>
           <li><a href="/customisation-haskell.html">Customisation in Haskell</a></li>
+	  <li><a href="/configuration-reference.html">Configuration reference</a></li>
           <li><a href="/synchronisation.html">Synchronisation</a></li>
           <li><a href="/blogposts.html">Featured blogposts</a></li>
           <hr>


### PR DESCRIPTION
SMOS is an interesting tool, but IMHO the user documentation is
lacking.  I'm voluntering to improve it.

I've added an initial concept page to explain the various concepts
that are spread around and a skeleton configuration reference page.

The configuration related to keybinding and command could be
generated since the source code contains some information.

This is still a WIP :-)