### PR TITLE
[#45] Support Proxies That Set Additional Cookies

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: cachix/install-nix-action@v6
+    - name: free disk space
+      run: |
+        sudo rm -rf /opt
     - uses: cachix/cachix-action@releases/v3
       with:
         name: validity

--- a/smos-api/src/Smos/API.hs
+++ b/smos-api/src/Smos/API.hs
@@ -114,7 +114,7 @@ instance ToJSON Register
 instance FromJSON Register
 
 type PostLogin =
-  "login" :> ReqBody '[JSON] Login :> PostNoContent '[JSON] (Headers '[Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] NoContent)
+  "login" :> ReqBody '[JSON] Login :> PostNoContent '[JSON] (Headers '[Header "Set-Cookie" T.Text] NoContent)
 
 data Login
   = Login


### PR DESCRIPTION
Ripped from https://github.com/NorfairKing/intray/pull/7

---

Add support for using the CLI client with proxied servers that append
their own cookies to the Set-Cookie header returned by the PostLogin API
route.

For example, servers proxied behind CloudFlare will get a __cfuid cookie
appended to the Set-Cookie header. Previously, the client would
incorrectly save the __cfuid cookie to the session.cookie file. We
prevent this by having the client's PostLogin handler parse the Cookies
itself, locate the correct JWT-Cookie cookie, and explicitly save that
cookie, instead relying on Servant's SetCookie parsing which simply
parses the first cookie it sees.

We also collapse the double "Set-Cookie" Header in the PostLogin API
route since it is no longer necessary.

Closes #45