### PR TITLE
add temp CI job to test syspolicy impact

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -42,3 +42,37 @@ jobs:
         name: smos
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix-build default.nix
+  macos_perf_test:
+    name: macos_perf_test / Nix
+    runs-on: macos-latest
+    steps:
+    - name: Disable syspolicy assessments
+      run: |
+        spctl --status
+        sudo spctl --master-disable
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v8
+    - name: free disk space
+      run: |
+        if [[ "${{matrix.os}}" == "ubuntu-latest" ]]
+        then
+          sudo rm -rf /opt
+        fi
+    - uses: cachix/cachix-action@v6
+      with:
+        name: validity
+    - uses: cachix/cachix-action@v6
+      with:
+        name: cursor
+    - uses: cachix/cachix-action@v6
+      with:
+        name: mergeful
+    - uses: cachix/cachix-action@v6
+      with:
+        name: yamlparse
+    - uses: cachix/cachix-action@v6
+      with:
+        name: smos
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - run: nix-build default.nix
+      


### PR DESCRIPTION
Starting in Catalina, macOS runs a syspolicyd "assessment" that hits the network for each binary/script executable. It does cache these results, but Nix tends to introduce many "new" executables per build. (You can read more about this at https://github.com/NixOS/nix/issues/3789).

This PR adds a temporary, redundant macOS job with these assessments disabled. I'm hoping you can adopt it for a few weeks to help me collect more data on how this affects real projects.

(I'm also hoping this runs clean. I've been waiting for these to run through before I PR, but I guess the CI config is only set to run on specific branches and pull, so they aren't automatically running beforehand. 🤞)