### PR TITLE
More CI improvements

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -32,4 +32,4 @@ jobs:
         name: smos
         extraPullNames: iohk,validity,dirforest,cursor,cursor-dirforest,mergeful,yamlparse
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build ci.nix
+    - run: nix run -f nix/build-uncached.nix -c nix-build-uncached ci.nix

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,5 @@
 let
-  pkgsv = import ./nix/pkgsv.nix;
-  pkgs = pkgsv { overlays = [ (import ./nix/ci-overlay.nix) ]; };
+  pkgs = import ./nix/ci-pkgs.nix;
   pre-commit-hooks = import ./nix/pre-commit.nix;
 in
 pkgs.smosPackages // {

--- a/nix/build-uncached.nix
+++ b/nix/build-uncached.nix
@@ -7,4 +7,4 @@ let
     sha256 = "sha256:1snwsmn8qcbvilhn0wqspqz3zkb0dhrb8bpbclbazi94dsgksxjy";
   };
 in
-import (nixBuildUncached + "/default.nix")
+import (nixBuildUncached + "/default.nix") { inherit pkgs; }

--- a/nix/build-uncached.nix
+++ b/nix/build-uncached.nix
@@ -1,0 +1,10 @@
+let
+  pkgs = import ./ci-pkgs.nix;
+  nixBuildUncached = pkgs.fetchFromGitHub {
+    owner = "Mic92";
+    repo = "nix-build-uncached";
+    rev = "611b17999fb1ddbf243a120d96a1232a320f1704";
+    sha256 = "sha256:1snwsmn8qcbvilhn0wqspqz3zkb0dhrb8bpbclbazi94dsgksxjy";
+  };
+in
+import (nixBuildUncached + "/default.nix")

--- a/nix/ci-overlay.nix
+++ b/nix/ci-overlay.nix
@@ -1,7 +1,7 @@
 final: previous:
 let
   ciVersionInfo = final.writeText "ci-version-info" ''
-    This is a CI build without version information
+    This is a CI build without version information. You should not be using this in practice because then you cannot submit good bug reports.
   '';
 in
 {

--- a/nix/ci-pkgs.nix
+++ b/nix/ci-pkgs.nix
@@ -1,0 +1,5 @@
+let
+  pkgsv = import ./pkgsv.nix;
+  pkgs = pkgsv { overlays = [ (import ./ci-overlay.nix) ]; };
+in
+pkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import ./nix/pkgs.nix;
+  pkgs = import ./nix/ci-pkgs.nix;
   pre-commit-hooks = import ./nix/pre-commit.nix;
 in
 pkgs.mkShell {


### PR DESCRIPTION
This tries out using nix-build-uncached (a recent version) on the ci build that has no build information built-in.