### PR TITLE
Select the value when selecting a TimestampsCursor

### DIFF
--- a/smos-cursor/src/Smos/Cursor/Timestamps.hs
+++ b/smos-cursor/src/Smos/Cursor/Timestamps.hs
@@ -165,12 +165,13 @@ timestampsCursorAppendAndSelect tsn d =
 timestampsCursorSelectOrAdd :: TimestampName -> LocalTime -> TimestampsCursor -> TimestampsCursor
 timestampsCursorSelectOrAdd tsn d =
   timestampsCursorMapCursorL
-    %~ mapCursorSelectOrAdd
-      rebuildTimestampNameCursor
-      makeTimestampNameCursor
-      rebuildTimestampCursor
-      (\t _ -> t == tsn)
-      (makeKeyValueCursorValue tsn (emptyFuzzyLocalTimeCursor d))
+    %~ mapCursorSelectValue rebuildTimestampNameCursor makeTimestampCursor
+    . mapCursorSelectOrAdd
+        rebuildTimestampNameCursor
+        makeTimestampNameCursor
+        rebuildTimestampCursor
+        (\t _ -> t == tsn)
+        (makeKeyValueCursorValue tsn (emptyFuzzyLocalTimeCursor d))
 
 timestampsCursorUpdateTime :: ZonedTime -> TimestampsCursor -> TimestampsCursor
 timestampsCursorUpdateTime zt = (timestampsCursorMapCursorL . mapCursorElemL) %~ go


### PR DESCRIPTION
This fixes #13.
Not much to say about this. Finding the right `TimestampName` puts the cursor on the key. This commit simply puts it on the value just after the find.