### PR TITLE
Delete timestamp

### DIFF
--- a/smos-cursor/src/Smos/Cursor/Timestamps.hs
+++ b/smos-cursor/src/Smos/Cursor/Timestamps.hs
@@ -23,6 +23,7 @@ module Smos.Cursor.Timestamps
     rebuildTimestampNameCursor,
     makeTimestampCursor,
     rebuildTimestampCursor,
+    timestampsCursorDeleteElem,
   )
 where
 
@@ -208,3 +209,11 @@ rebuildTimestampCursor fltc =
   case rebuildFuzzyLocalTimeCursor fltc of
     OnlyDaySpecified d -> TimestampDay d
     BothTimeAndDay lt -> TimestampLocalTime lt
+
+timestampsCursorDeleteElem :: TimestampsCursor -> Maybe TimestampsCursor
+timestampsCursorDeleteElem = timestampsCursorMapCursorL . localMapCursorListL $ remo
+  where
+    localMapCursorListL = lens mapCursorList (\x y -> x {mapCursorList = y})
+    -- This should be removed if mapCursorListL is added to the Cursor library
+    mkcursor (k, v) = makeKeyValueCursorKey (makeTimestampNameCursor k) v
+    remo = dullMDelete . nonEmptyCursorDeleteElemAndSelectNext mkcursor

--- a/smos/src/Smos/Actions/Entry/Timestamps.hs
+++ b/smos/src/Smos/Actions/Entry/Timestamps.hs
@@ -11,6 +11,7 @@ module Smos.Actions.Entry.Timestamps
     timestampsRemove,
     timestampsDelete,
     timestampsToggle,
+    timestampsDeleteStamp,
   )
 where
 
@@ -30,7 +31,8 @@ allTimestampsPlainActions =
         timestampsMoveRight,
         timestampsRemove,
         timestampsDelete,
-        timestampsToggle
+        timestampsToggle,
+        timestampsDeleteStamp
       ]
     ]
 
@@ -111,4 +113,12 @@ timestampsToggle =
     { actionName = "timestampsToggle",
       actionFunc = modifyTimestampsCursor timestampsCursorToggleSelected,
       actionDescription = "Switch between selecting the timestamp name or date"
+    }
+
+timestampsDeleteStamp :: Action
+timestampsDeleteStamp =
+  Action
+    { actionName = "timeStampsDeleteStamp",
+      actionFunc = modifyMTimestampsCursorM (timestampsCursorDeleteElem =<<),
+      actionDescription = "Delete the timestamp"
     }

--- a/smos/src/Smos/Default.hs
+++ b/smos/src/Smos/Default.hs
@@ -111,6 +111,7 @@ defaultFileKeyMap =
             exactString "se" $ timestampsSelect "END",
             exactString "sd" $ timestampsSelect "DEADLINE",
             exactString "ss" $ timestampsSelect "SCHEDULED",
+            exactString "s " timestampsDeleteStamp,
             exactString "pi" entrySelectProperties,
             exactString "pc" $ propertiesEditProperty "client",
             exactString "pt" $ propertiesEditProperty "timewindow",


### PR DESCRIPTION
Hi, 

I believe this does the job. I added a function to delete the focused element in a TimestampsCursor and focus on the previous element.

```haskell
timestampsCursorDeleteElem :: TimestampsCursor -> Maybe TimestampsCursor
timestampsCursorDeleteElem = timestampsCursorMapCursorL . localMapCursorListL $ remo
  where
    localMapCursorListL = lens mapCursorList (\x y -> x {mapCursorList = y})
    -- This should be removed if mapCursorListL is added to the Cursor library
    mkcursor (k, v) = makeKeyValueCursorKey (makeTimestampNameCursor k) v
    remo = dullMDelete . nonEmptyCursorDeleteElemAndSelectNext mkcursor
```

Then I added an action for deleting a timestamp:

```haskell 
timestampsDeleteStamp :: Action
timestampsDeleteStamp =
  Action
    { actionName = "timeStampsDeleteStamp",
      actionFunc = modifyMTimestampsCursorM (timestampsCursorDeleteElem =<<),
      actionDescription = "Delete the timestamp"
    }
```

and then set the default command as "s<SPACE>"

```haskell
            exactString "s " timestampsDeleteStamp,
```