### PR TITLE
Incorrect description for the archive action

### DIFF
--- a/smos/src/Smos/Actions/Browser.hs
+++ b/smos/src/Smos/Actions/Browser.hs
@@ -244,7 +244,7 @@ browserArchive =
         ad <- liftIO $ resolveReportArchiveDir src
         wd <- liftIO $ resolveReportWorkflowDir src
         fileBrowserArchiveFile wd ad fbc,
-      actionDescription = "Remove the currently selected empty directory. This does nothing if the directory is not empty."
+      actionDescription = "Move the current file to the Archive."
     }
 
 browserCompleteDir :: Action


### PR DESCRIPTION
The `browserArchive` has the same description as `browserRemoveEmptyDir`. Updated the description to match the actual description of the action.