### PR TITLE
Don't Set TODO State if Template State Set to null

### DIFF
--- a/smos-docs-site/content/pages/changelog.markdown
+++ b/smos-docs-site/content/pages/changelog.markdown
@@ -11,6 +11,11 @@ description: The changelog for all of the Smos tools and libraries
   You can now use `timestamp:DEADLINE` as a column in your reports.
 - Interactive agenda report.
 
+## Changed
+
+- `smos-scheduler`: Explicitly setting a header's `state` to `null` now leaves the generated state as null instead of setting it to `TODO`.
+
+
 # <a name="2021-02-01">[2021-02-01](#2021-02-01)
 - <a name="smos-0.1.3">[smos 0.1.3](#smos-0.1.3)
 - <a name="smos-query-0.1.2">[smos-query 0.1.2](#smos-query-0.1.2)

--- a/smos-scheduler/src/Smos/Scheduler/OptParse/Types.hs
+++ b/smos-scheduler/src/Smos/Scheduler/OptParse/Types.hs
@@ -197,7 +197,7 @@ data EntryTemplate = EntryTemplate
     entryTemplateContents :: Maybe Contents,
     entryTemplateTimestamps :: Map TimestampName TimestampTemplate,
     entryTemplateProperties :: Map PropertyName PropertyValue,
-    entryTemplateState :: Maybe TodoState,
+    entryTemplateState :: Maybe (Maybe TodoState),
     entryTemplateTags :: Set Tag
   }
   deriving (Show, Eq, Generic)
@@ -217,14 +217,22 @@ newEntryTemplate h =
 
 instance ToJSON EntryTemplate where
   toJSON EntryTemplate {..} =
-    object
+    object $
       [ "header" .= entryTemplateHeader,
         "contents" .= entryTemplateContents,
         "timestamps" .= entryTemplateTimestamps,
         "properties" .= entryTemplateProperties,
-        "state" .= entryTemplateState,
         "tags" .= entryTemplateTags
       ]
+        <> stateToJson
+    where
+      stateToJson =
+        case entryTemplateState of
+          Nothing ->
+            []
+          Just v ->
+            [ "state" .= v
+            ]
 
 instance FromJSON EntryTemplate where
   parseJSON v =
@@ -238,7 +246,7 @@ instance FromJSON EntryTemplate where
                 <*> o .:? "contents"
                 <*> o .:? "timestamps" .!= M.empty
                 <*> o .:? "properties" .!= M.empty
-                <*> o .:? "state" .!= Nothing
+                <*> o .:! "state"
                 <*> o .:? "tags" .!= S.empty
           )
         v

--- a/smos-scheduler/src/Smos/Scheduler/Render.hs
+++ b/smos-scheduler/src/Smos/Scheduler/Render.hs
@@ -77,10 +77,18 @@ renderPropertyValueTemplate pv = do
     Nothing -> renderFail $ RenderErrorPropertyValueValidity pv t
     Just pv' -> pure pv'
 
-renderStateHistoryTemplate :: Maybe TodoState -> Render StateHistory
+-- | `Nothing` means the state field doesn't exist, while `Just Nothing`
+-- means it is explicitly set to `null`.
+renderStateHistoryTemplate :: Maybe (Maybe TodoState) -> Render StateHistory
 renderStateHistoryTemplate mts = do
   now <- asks renderContextTime
-  pure $ StateHistory [StateHistoryEntry {stateHistoryEntryNewState = Just $ fromMaybe "TODO" mts, stateHistoryEntryTimestamp = zonedTimeToUTC now}]
+  pure $
+    StateHistory
+      [ StateHistoryEntry
+          { stateHistoryEntryNewState = fromMaybe (Just $ TodoState "TODO") mts,
+            stateHistoryEntryTimestamp = zonedTimeToUTC now
+          }
+      ]
 
 renderTodoStateTemplate :: TodoState -> Render TodoState
 renderTodoStateTemplate = fmap TodoState . renderTextTemplate . todoStateText


### PR DESCRIPTION
Currently, explicitly setting `state: null` in a template will be ignored, resulting in a `state: TODO` in the generated file.

This commit changes this behavior, causing the renderer to only set the generated state to `TODO` if the `state` field is missing.

Instead of parsing a `Maybe TodoState` from the template, we parse a `Maybe (Maybe TodoState)`. The `Nothing` case indicates the field does not exist, while the `Just Nothing` indicates it was explicitly set to `null`.