### PR TITLE
Add a .lock extension to the metadata DB filename

### DIFF
--- a/smos-sync-client/src/Smos/Sync/Client/Command/Sync.hs
+++ b/smos-sync-client/src/Smos/Sync/Client/Command/Sync.hs
@@ -61,7 +61,7 @@ syncSmosSyncClient Settings {..} SyncSettings {..} = do
   withFileLock (fromAbsFile syncSetMetadataDB) Exclusive $ \_ ->
     runStderrLoggingT $
       filterLogger (\_ ll -> ll >= setLogLevel) $
-        DB.withSqlitePool (T.pack $ fromAbsFile syncSetMetadataDB) 1 $
+        DB.withSqlitePool (T.pack $ fromAbsFile syncSetMetadataDB <> ".lock") 1 $
           \pool ->
             withClientEnv setServerUrl $ \cenv -> withClientVersionCheck cenv $
               withLogin cenv setSessionPath setUsername setPassword $ \token ->


### PR DESCRIPTION
Fixes #202 

Added a ".lock" extension to the `syncSetMetadataDB` when running sync.

@NorfairKing should this be added elsewhere as well?