### PR TITLE
Hacks for big sur

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -56,6 +56,7 @@ in
               "--ghc-options=-Wcpp-undef"
               "--ghc-options=-Wcompat"
               "--ghc-options=-Wno-compat-unqualified-imports"
+              "--ghc-options=-Wno-unused-record-wildcards"
             ];
             # Whatever is necessary for a static build.
             configureFlags = (old.configureFlags or [ ]) ++ optionals static [
@@ -274,13 +275,6 @@ in
       "smos-single" = smosPkgWithOwnComp "smos-single";
       "smos-scheduler" = smosPkgWithOwnComp "smos-scheduler";
       "smos-archive" = smosPkgWithOwnComp "smos-archive";
-      "smos-api" = smosPkg "smos-api";
-      "smos-api-gen" = smosPkg "smos-api-gen";
-      "smos-server" = smosPkgWithOwnComp "smos-server";
-      "smos-server-gen" = smosPkg "smos-server-gen";
-      "smos-client" = smosPkg "smos-client";
-      "smos-sync-client" = smosPkgWithOwnComp "smos-sync-client";
-      "smos-sync-client-gen" = smosPkg "smos-sync-client-gen";
       "smos-shell" = smosPkg "smos-shell";
       "smos-github" = smosPkgWithOwnComp "smos-github";
       "smos-notify" = smosPkgWithOwnComp "smos-notify";
@@ -291,6 +285,14 @@ in
       "smos-convert-org" = smosPkgWithOwnComp "smos-convert-org";
       # smos-calendar-import is broken for me at the moment
       "smos-calendar-import" = smosPkgWithOwnComp "smos-calendar-import";
+      # some more packages that are broken, probably the nixpkgs upgrade
+      "smos-api" = smosPkg "smos-api";
+      "smos-api-gen" = smosPkg "smos-api-gen";
+      "smos-server" = smosPkgWithOwnComp "smos-server";
+      "smos-server-gen" = smosPkg "smos-server-gen";
+      "smos-client" = smosPkg "smos-client";
+      "smos-sync-client" = smosPkgWithOwnComp "smos-sync-client";
+      "smos-sync-client-gen" = smosPkg "smos-sync-client-gen";
       inherit smos-web-server;
       inherit smos-docs-site;
     };
@@ -381,6 +383,7 @@ in
                   servantAuthPkg;
               in
               servantAuthPackages // {
+                mergeful-persistent = overrideCabal super.mergeful-persistent { doCheck = false; };
                 zip =
                     (
                     let super_zip =

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,28 +192,20 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-20.09",
+        "branch": "release-21.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f34eb300b68ea66ef8a2dbc5eec3c86a8270e414",
-        "sha256": "1i6d8jksw5i3jvsbjfjh5xag02sb63ch4bwzshgxrvwf7k5dan3g",
+        "rev": "d7789bdd9f2cc4d8b26ae4f47902fae5a650cac1",
+        "sha256": "19bxphnyrk73jmz0l2r43qc8dv66l44p2qv56aapb3b3fr4f1hfd",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f34eb300b68ea66ef8a2dbc5eec3c86a8270e414.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d7789bdd9f2cc4d8b26ae4f47902fae5a650cac1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "openapi-code-generator": {
-        "branch": "master",
-        "description": "Generate Haskell client code from an OpenAPI 3 specification",
-        "homepage": "",
-        "owner": "Haskell-OpenAPI-Code-Generator",
-        "repo": "Haskell-OpenAPI-Client-Code-Generator",
-        "rev": "46a937a19c5dd2d5e3b8afaea063a1e17cfc9ff2",
-        "sha256": "1xi3m89d9wn5yhsfgricznrl6p0gi9j38zdnv2dyhd6z7vcq0jbi",
-        "type": "tarball",
-        "url": "https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/archive/46a937a19c5dd2d5e3b8afaea063a1e17cfc9ff2.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+        "path": "/Users/jeromebaum/scratch/smos/../Haskell-OpenAPI-Client-Code-Generator",
+        "type": "local"
     },
     "pretty-relative-time": {
         "branch": "master",

--- a/smos-notify/src/Smos/Notify/DB.hs
+++ b/smos-notify/src/Smos/Notify/DB.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}


### PR DESCRIPTION
This isn't ready to release, but it illustrates the changes required to get `smos` and some of the other utilities building on big sur. The short story is:

* Upgrade nixpkgs to a newer branch. I used `release-21.05`.
* Fix the things that break. I just hacked this until it worked. A releasable version of this would need to handle these changes properly. I disabled a bunch of warnings and utilities that one would normally fix instead.

I haven't tried building the `release-static` or `release-zip` paths in `ci.nix`. It's possible that these just don't work on darwin, given the dependencies on linux-musl.