### PR TITLE
[nix] add data-dir option for web-server

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -238,6 +238,13 @@ in
                       example = "https://smos.online";
                       description = "The url that this web server is served from.";
                     };
+                  data-dir =
+                    mkOption {
+                      type = types.nullOr types.str;
+                      default = null;
+                      example = "/www/smos/production/web-server/web-server/";
+                      description = "The directory to store workflows during editing";
+                    };
                   log-level =
                     mkOption {
                       type = types.str;


### PR DESCRIPTION
Currently we will encounter error: The option `services.smos.production.web-server.data-dir' does not exist.