### PR TITLE
Introduce Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,384 @@
+{
+  "nodes": {
+    "autodocodec": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1655663621,
+        "narHash": "sha256-SY2fcplqccWisa/MQ3idoBVZpqezGv2nt00uZiFYfog=",
+        "owner": "NorfairKing",
+        "repo": "autodocodec",
+        "rev": "a60fbd4db121c0529f9ceb68c58c289daa693db2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "autodocodec",
+        "rev": "a60fbd4db121c0529f9ceb68c58c289daa693db2",
+        "type": "github"
+      }
+    },
+    "cursor": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1638524819,
+        "narHash": "sha256-8lKvOn4sTlZXMcExMSPug1TLtw8filHGj7D9/q9zFKw=",
+        "owner": "NorfairKing",
+        "repo": "cursor",
+        "rev": "5f18d58d1b34a752d24a94590c2cd35e8b6d557b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "cursor",
+        "rev": "5f18d58d1b34a752d24a94590c2cd35e8b6d557b",
+        "type": "github"
+      }
+    },
+    "cursor-brick": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637535128,
+        "narHash": "sha256-ctDIexjnyLD5k4CACoG7hKsFXN35azUa4e0nVt/jNs4=",
+        "owner": "NorfairKing",
+        "repo": "cursor-brick",
+        "rev": "5c1d1306632403a3dc11ddeda10deee932c0b307",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "cursor-brick",
+        "rev": "5c1d1306632403a3dc11ddeda10deee932c0b307",
+        "type": "github"
+      }
+    },
+    "cursor-dirforest": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637536969,
+        "narHash": "sha256-UsAJ9nuwXSuX34dYc4w73XQK6fMvXrajkxJF3yAzPlY=",
+        "owner": "NorfairKing",
+        "repo": "cursor-dirforest",
+        "rev": "6ad5b168e26eb4e647df9f007d812aaf59338d40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "cursor-dirforest",
+        "rev": "6ad5b168e26eb4e647df9f007d812aaf59338d40",
+        "type": "github"
+      }
+    },
+    "cursor-fuzzy-time": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637534411,
+        "narHash": "sha256-/SRvDS/5hTeM5vni1hIwQV1MUSjdNI2xGFIBm+xMgho=",
+        "owner": "NorfairKing",
+        "repo": "cursor-fuzzy-time",
+        "rev": "86830e3c14e1ec054e4423742eb34d1c49f9b8b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "cursor-fuzzy-time",
+        "rev": "86830e3c14e1ec054e4423742eb34d1c49f9b8b0",
+        "type": "github"
+      }
+    },
+    "dirforest": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637536286,
+        "narHash": "sha256-pGZAtMMfjJPA/3aRi+O6rCcZ48EO1lu1zzlbQ/xxrzQ=",
+        "owner": "NorfairKing",
+        "repo": "dirforest",
+        "rev": "69e8ae036b047fae105c1fe990e175a7572a3eba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "dirforest",
+        "rev": "69e8ae036b047fae105c1fe990e175a7572a3eba",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fuzzy-time": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637523558,
+        "narHash": "sha256-57HoBUlYH1msOXSXu+UBKHRynEe+IgY1Vg6AhZ4p5XU=",
+        "owner": "NorfairKing",
+        "repo": "fuzzy-time",
+        "rev": "af42de90fd04d8506a440f439c6628c64d33b7d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "fuzzy-time",
+        "rev": "af42de90fd04d8506a440f439c6628c64d33b7d2",
+        "type": "github"
+      }
+    },
+    "iCalendar": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1638882714,
+        "narHash": "sha256-wcPWHMMUL93borR5wQawoGJgyJ9jxZw7eGwSEG3rcGo=",
+        "owner": "NorfairKing",
+        "repo": "iCalendar",
+        "rev": "e08c16dceaab4d15b0f00860512018bc64791f07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "iCalendar",
+        "rev": "e08c16dceaab4d15b0f00860512018bc64791f07",
+        "type": "github"
+      }
+    },
+    "looper": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651920996,
+        "narHash": "sha256-XEIJ6rzZOP5X9RIai6vqRbcZ9GhoSYmTTjJW6nIqKas=",
+        "owner": "NorfairKing",
+        "repo": "looper",
+        "rev": "6f7d44f563a7e21c3ca5fa24ebe01ed1665426ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "looper",
+        "rev": "6f7d44f563a7e21c3ca5fa24ebe01ed1665426ca",
+        "type": "github"
+      }
+    },
+    "mergeful": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1655663735,
+        "narHash": "sha256-ppDmpH+6DQ9OxzxeRuNkxFMa83hWwXaJqpszLOr1UrA=",
+        "owner": "NorfairKing",
+        "repo": "mergeful",
+        "rev": "3b6beea95dcb8ce3db9c11fec0481cd10123476c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "mergeful",
+        "rev": "3b6beea95dcb8ce3db9c11fec0481cd10123476c",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1659988782,
+        "narHash": "sha256-mi7DRvQZdbCFqMLAmptYcNqNrTnTtuY6DYjhC11Jw44=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fb520531bbed31c8f4adbc9aa87a786eec2f51f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "org-parser": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654477103,
+        "narHash": "sha256-e4z9rIw9qyH3+9/FB2+H0S24hI/sp6poefp4gpSB/AA=",
+        "owner": "lucasvreis",
+        "repo": "org-parser",
+        "rev": "c81233122812d795087b313e100c759af8709e31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lucasvreis",
+        "repo": "org-parser",
+        "rev": "c81233122812d795087b313e100c759af8709e31",
+        "type": "github"
+      }
+    },
+    "pretty-relative-time": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637431698,
+        "narHash": "sha256-QUQEUEl8ixj37pgbyIEonOpSv7HM8g6eJTfv84UJYng=",
+        "owner": "NorfairKing",
+        "repo": "pretty-relative-time",
+        "rev": "a634358ff274380a12360f7814c3aea46ea35b1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "pretty-relative-time",
+        "rev": "a634358ff274380a12360f7814c3aea46ea35b1b",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "autodocodec": "autodocodec",
+        "cursor": "cursor",
+        "cursor-brick": "cursor-brick",
+        "cursor-dirforest": "cursor-dirforest",
+        "cursor-fuzzy-time": "cursor-fuzzy-time",
+        "dirforest": "dirforest",
+        "flake-utils": "flake-utils",
+        "fuzzy-time": "fuzzy-time",
+        "iCalendar": "iCalendar",
+        "looper": "looper",
+        "mergeful": "mergeful",
+        "nixpkgs": "nixpkgs",
+        "org-parser": "org-parser",
+        "pretty-relative-time": "pretty-relative-time",
+        "safe-coloured-text": "safe-coloured-text",
+        "sydtest": "sydtest",
+        "template-haskell-reload": "template-haskell-reload",
+        "typed-uuid": "typed-uuid",
+        "validity": "validity",
+        "yesod-autoreload": "yesod-autoreload",
+        "yesod-static-remote": "yesod-static-remote"
+      }
+    },
+    "safe-coloured-text": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1655642621,
+        "narHash": "sha256-Fl3cOE2cytLPZvmM+yeCuDoj2KtZzRLJtKv2CEGEMY0=",
+        "owner": "NorfairKing",
+        "repo": "safe-coloured-text",
+        "rev": "d1a727998fa58ecf38022906b552d33e57e3f308",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "safe-coloured-text",
+        "rev": "d1a727998fa58ecf38022906b552d33e57e3f308",
+        "type": "github"
+      }
+    },
+    "sydtest": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654588919,
+        "narHash": "sha256-7Hf7KZ6Kap4M5Co+POf+kui44BDklyzwYW9SIL7Kynw=",
+        "owner": "NorfairKing",
+        "repo": "sydtest",
+        "rev": "cf1bb414f0c0ce7bbf64659da94b8cd890c9e536",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "sydtest",
+        "rev": "cf1bb414f0c0ce7bbf64659da94b8cd890c9e536",
+        "type": "github"
+      }
+    },
+    "template-haskell-reload": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1655768786,
+        "narHash": "sha256-cYB4w0H/zY+QKCl4hx2aK19tCCLi41M36HZRoDdqC98=",
+        "owner": "NorfairKing",
+        "repo": "template-haskell-reload",
+        "rev": "c416550db3f353bad65980a8ecd9b3b81fa504bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "template-haskell-reload",
+        "rev": "c416550db3f353bad65980a8ecd9b3b81fa504bd",
+        "type": "github"
+      }
+    },
+    "typed-uuid": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637768590,
+        "narHash": "sha256-88CS8aQjAswvpimXXawYRQ3aYpXieYfp1oVebs8apmc=",
+        "owner": "NorfairKing",
+        "repo": "typed-uuid",
+        "rev": "00fbc7e0380ab2ff72e8fd02323e76f13b7d5b59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "typed-uuid",
+        "rev": "00fbc7e0380ab2ff72e8fd02323e76f13b7d5b59",
+        "type": "github"
+      }
+    },
+    "validity": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1655605427,
+        "narHash": "sha256-5wEgqr+ndFQ4jz7MQK6UvwwA1kQyQPyCxOmUc3eiHyE=",
+        "owner": "NorfairKing",
+        "repo": "validity",
+        "rev": "d88be911a7e2a84f6c089e9269aaed8d10a74acd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "validity",
+        "rev": "d88be911a7e2a84f6c089e9269aaed8d10a74acd",
+        "type": "github"
+      }
+    },
+    "yesod-autoreload": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622291603,
+        "narHash": "sha256-zXxgZu24BCLra2JfXuZa6FOEJQJwHayWAKZGlTAOuVg=",
+        "owner": "NorfairKing",
+        "repo": "yesod-autoreload",
+        "rev": "7135e864c0d4a48efeae473ee2761f5168946e58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "yesod-autoreload",
+        "rev": "7135e864c0d4a48efeae473ee2761f5168946e58",
+        "type": "github"
+      }
+    },
+    "yesod-static-remote": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1605534063,
+        "narHash": "sha256-rIe81cPXgQnBT26HOUwejYfD5lH1gy6XHRitb2wsyms=",
+        "owner": "NorfairKing",
+        "repo": "yesod-static-remote",
+        "rev": "ed6bf8ef434d49b160429028613a1f6882fccfdf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NorfairKing",
+        "repo": "yesod-static-remote",
+        "rev": "ed6bf8ef434d49b160429028613a1f6882fccfdf",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,8 @@
             addBuildDeps = deps: pkg: pkg.overrideAttrs (old: {
               nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ deps;
             });
+
+            disableTestsOnMac = if pkgs.stdenv.isDarwin then pkgs.haskell.lib.dontCheck else x: x;
           in
           {
             # Dependencies
@@ -255,11 +257,12 @@
                 (validity + /genvalidity-criterion)
                 { };
 
-            genvalidity-dirforest =
+            genvalidity-dirforest = disableTestsOnMac (
               final.callCabal2nix
                 "genvalidity-dirforest"
                 (dirforest + /genvalidity-dirforest)
-                { };
+                { }
+            );
 
             genvalidity-hspec =
               final.callCabal2nix
@@ -616,10 +619,11 @@
                 { };
 
             # Smos packages
-            smos =
+            smos = disableTestsOnMac (
               final.callCabal2nix
                 "smos" ./smos
-                { };
+                { }
+            );
 
             smos-api =
               final.callCabal2nix
@@ -631,10 +635,12 @@
                 "smos-api-gen" ./smos-api-gen
                 { };
 
-            smos-archive = addBuildDeps [ final.autoexporter ] (
-              final.callCabal2nix
-                "smos-archive" ./smos-archive
-                { }
+            smos-archive = disableTestsOnMac (
+              addBuildDeps [ final.autoexporter ] (
+                final.callCabal2nix
+                  "smos-archive" ./smos-archive
+                  { }
+              )
             );
 
             smos-calendar-import =
@@ -652,10 +658,11 @@
                 "smos-cursor" ./smos-cursor
                 { };
 
-            smos-cursor-gen =
+            smos-cursor-gen = disableTestsOnMac (
               final.callCabal2nix
                 "smos-cursor-gen" ./smos-cursor-gen
-                { };
+                { }
+            );
 
             smos-data =
               final.callCabal2nix
@@ -697,10 +704,11 @@
                 "smos-report-cursor-gen" ./smos-report-cursor-gen
                 { };
 
-            smos-report-gen =
+            smos-report-gen = disableTestsOnMac (
               final.callCabal2nix
                 "smos-report-gen" ./smos-report-gen
-                { };
+                { }
+            );
 
             smos-scheduler =
               final.callCabal2nix

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,760 @@
+{
+  description = "Smos";
+
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs;
+    flake-utils.url = github:numtide/flake-utils;
+
+    # Dependencies extracted from stack.yaml
+    org-parser = {
+      url = github:lucasvreis/org-parser/c81233122812d795087b313e100c759af8709e31;
+      flake = false;
+    };
+
+    iCalendar = {
+      url = github:NorfairKing/iCalendar/e08c16dceaab4d15b0f00860512018bc64791f07;
+      flake = false;
+    };
+
+    typed-uuid = {
+      url = github:NorfairKing/typed-uuid/00fbc7e0380ab2ff72e8fd02323e76f13b7d5b59;
+      flake = false;
+    };
+
+    mergeful = {
+      url = github:NorfairKing/mergeful/3b6beea95dcb8ce3db9c11fec0481cd10123476c;
+      flake = false;
+    };
+
+    looper = {
+      url = github:NorfairKing/looper/6f7d44f563a7e21c3ca5fa24ebe01ed1665426ca;
+      flake = false;
+    };
+
+    pretty-relative-time = {
+      url = github:NorfairKing/pretty-relative-time/a634358ff274380a12360f7814c3aea46ea35b1b;
+      flake = false;
+    };
+
+    cursor-fuzzy-time = {
+      url = github:NorfairKing/cursor-fuzzy-time/86830e3c14e1ec054e4423742eb34d1c49f9b8b0;
+      flake = false;
+    };
+
+    fuzzy-time = {
+      url = github:NorfairKing/fuzzy-time/af42de90fd04d8506a440f439c6628c64d33b7d2;
+      flake = false;
+    };
+
+    dirforest = {
+      url = github:NorfairKing/dirforest/69e8ae036b047fae105c1fe990e175a7572a3eba;
+      flake = false;
+    };
+
+    cursor-dirforest = {
+      url = github:NorfairKing/cursor-dirforest/6ad5b168e26eb4e647df9f007d812aaf59338d40;
+      flake = false;
+    };
+
+    cursor-brick = {
+      url = github:NorfairKing/cursor-brick/5c1d1306632403a3dc11ddeda10deee932c0b307;
+      flake = false;
+    };
+
+    cursor = {
+      url = github:NorfairKing/cursor/5f18d58d1b34a752d24a94590c2cd35e8b6d557b;
+      flake = false;
+    };
+
+    autodocodec = {
+      url = github:NorfairKing/autodocodec/a60fbd4db121c0529f9ceb68c58c289daa693db2;
+      flake = false;
+    };
+
+    safe-coloured-text = {
+      url = github:NorfairKing/safe-coloured-text/d1a727998fa58ecf38022906b552d33e57e3f308;
+      flake = false;
+    };
+
+    sydtest = {
+      url = github:NorfairKing/sydtest/cf1bb414f0c0ce7bbf64659da94b8cd890c9e536;
+      flake = false;
+    };
+
+    validity = {
+      url = github:NorfairKing/validity/d88be911a7e2a84f6c089e9269aaed8d10a74acd;
+      flake = false;
+    };
+
+    yesod-static-remote = {
+      url = github:NorfairKing/yesod-static-remote/ed6bf8ef434d49b160429028613a1f6882fccfdf;
+      flake = false;
+    };
+
+    yesod-autoreload = {
+      url = github:NorfairKing/yesod-autoreload/7135e864c0d4a48efeae473ee2761f5168946e58;
+      flake = false;
+    };
+
+    template-haskell-reload = {
+      url = github:NorfairKing/template-haskell-reload/c416550db3f353bad65980a8ecd9b3b81fa504bd;
+      flake = false;
+    };
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , org-parser
+    , iCalendar
+    , typed-uuid
+    , mergeful
+    , looper
+    , pretty-relative-time
+    , cursor-fuzzy-time
+    , fuzzy-time
+    , dirforest
+    , cursor-dirforest
+    , cursor-brick
+    , cursor
+    , autodocodec
+    , safe-coloured-text
+    , sydtest
+    , validity
+    , yesod-static-remote
+    , yesod-autoreload
+    , template-haskell-reload
+    }:
+
+    flake-utils.lib.eachDefaultSystem (
+      system:
+
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        haskellPackages = pkgs.haskell.packages.ghc902.extend (final: prev:
+          let
+            addBuildDeps = deps: pkg: pkg.overrideAttrs (old: {
+              nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ deps;
+            });
+          in
+          {
+            # Dependencies
+            autodocodec =
+              final.callCabal2nix
+                "autodocodec"
+                (autodocodec + /autodocodec)
+                { };
+
+            autodocodec-schema =
+              final.callCabal2nix
+                "autodocodec-schema"
+                (autodocodec + /autodocodec-schema)
+                { };
+
+            autodocodec-yaml =
+              final.callCabal2nix
+                "autodocodec-yaml"
+                (autodocodec + /autodocodec-yaml)
+                { };
+
+            cursor =
+              final.callCabal2nix
+                "cursor"
+                (cursor + /cursor)
+                { };
+
+            cursor-brick =
+              final.callCabal2nix
+                "cursor-brick"
+                (cursor-brick + /cursor-brick)
+                { };
+
+            cursor-dirforest =
+              final.callCabal2nix
+                "cursor-dirforest"
+                (cursor-dirforest + /cursor-dirforest)
+                { };
+
+            cursor-dirforest-brick =
+              final.callCabal2nix
+                "cursor-dirforest-brick"
+                (cursor-dirforest + /cursor-dirforest-brick)
+                { };
+
+            cursor-dirforest-gen =
+              final.callCabal2nix
+                "cursor-dirforest-gen"
+                (cursor-dirforest + /cursor-dirforest-gen)
+                { };
+
+            cursor-fuzzy-time =
+              final.callCabal2nix
+                "cursor-fuzzy-time"
+                (cursor-fuzzy-time + /cursor-fuzzy-time)
+                { };
+
+            cursor-fuzzy-time-gen =
+              final.callCabal2nix
+                "cursor-fuzzy-time-gen"
+                (cursor-fuzzy-time + /cursor-fuzzy-time-gen)
+                { };
+
+            cursor-gen =
+              final.callCabal2nix
+                "cursor-gen"
+                (cursor + /cursor-gen)
+                { };
+
+            dirforest =
+              final.callCabal2nix
+                "dirforest"
+                (dirforest + /dirforest)
+                { };
+
+            fuzzy-time =
+              final.callCabal2nix
+                "fuzzy-time"
+                (fuzzy-time + /fuzzy-time)
+                { };
+
+            fuzzy-time-gen =
+              final.callCabal2nix
+                "fuzzy-time-gen"
+                (fuzzy-time + /fuzzy-time-gen)
+                { };
+
+            genvalidity =
+              final.callCabal2nix
+                "genvalidity"
+                (validity + /genvalidity)
+                { };
+
+            genvalidity-aeson =
+              final.callCabal2nix
+                "genvalidity-aeson"
+                (validity + /genvalidity-aeson)
+                { };
+
+            genvalidity-bytestring =
+              final.callCabal2nix
+                "genvalidity-bytestring"
+                (validity + /genvalidity-bytestring)
+                { };
+
+            genvalidity-containers =
+              final.callCabal2nix
+                "genvalidity-containers"
+                (validity + /genvalidity-containers)
+                { };
+
+            genvalidity-criterion =
+              final.callCabal2nix
+                "genvalidity-criterion"
+                (validity + /genvalidity-criterion)
+                { };
+
+            genvalidity-dirforest =
+              final.callCabal2nix
+                "genvalidity-dirforest"
+                (dirforest + /genvalidity-dirforest)
+                { };
+
+            genvalidity-hspec =
+              final.callCabal2nix
+                "genvalidity-hspec"
+                (validity + /genvalidity-hspec)
+                { };
+
+            genvalidity-hspec-aeson =
+              final.callCabal2nix
+                "genvalidity-hspec-aeson"
+                (validity + /genvalidity-hspec-aeson)
+                { };
+
+            genvalidity-hspec-binary =
+              final.callCabal2nix
+                "genvalidity-hspec-binary"
+                (validity + /genvalidity-hspec-binary)
+                { };
+
+            genvalidity-hspec-cereal =
+              final.callCabal2nix
+                "genvalidity-hspec-cereal"
+                (validity + /genvalidity-hspec-cereal)
+                { };
+
+            genvalidity-hspec-hashable =
+              final.callCabal2nix
+                "genvalidity-hspec-hashable"
+                (validity + /genvalidity-hspec-hashable)
+                { };
+
+            genvalidity-hspec-optics =
+              final.callCabal2nix
+                "genvalidity-hspec-optics"
+                (validity + /genvalidity-hspec-optics)
+                { };
+
+            genvalidity-hspec-persistent =
+              final.callCabal2nix
+                "genvalidity-hspec-persistent"
+                (validity + /genvalidity-hspec-persistent)
+                { };
+
+            genvalidity-mergeful =
+              final.callCabal2nix
+                "genvalidity-mergeful"
+                (mergeful + /genvalidity-mergeful)
+                { };
+
+            genvalidity-path =
+              final.callCabal2nix
+                "genvalidity-path"
+                (validity + /genvalidity-path)
+                { };
+
+            genvalidity-persistent =
+              final.callCabal2nix
+                "genvalidity-persistent"
+                (validity + /genvalidity-persistent)
+                { };
+
+            genvalidity-property =
+              final.callCabal2nix
+                "genvalidity-property"
+                (validity + /genvalidity-property)
+                { };
+
+            genvalidity-scientific =
+              final.callCabal2nix
+                "genvalidity-scientific"
+                (validity + /genvalidity-scientific)
+                { };
+
+            genvalidity-sydtest =
+              final.callCabal2nix
+                "genvalidity-sydtest"
+                (validity + /genvalidity-sydtest)
+                { };
+
+            genvalidity-sydtest-aeson =
+              final.callCabal2nix
+                "genvalidity-sydtest-aeson"
+                (validity + /genvalidity-sydtest-aeson)
+                { };
+
+            genvalidity-sydtest-hashable =
+              final.callCabal2nix
+                "genvalidity-sydtest-hashable"
+                (validity + /genvalidity-sydtest-hashable)
+                { };
+
+            genvalidity-sydtest-lens =
+              final.callCabal2nix
+                "genvalidity-sydtest-lens"
+                (validity + /genvalidity-sydtest-lens)
+                { };
+
+            genvalidity-sydtest-persistent =
+              final.callCabal2nix
+                "genvalidity-sydtest-persistent"
+                (validity + /genvalidity-sydtest-persistent)
+                { };
+
+            genvalidity-text =
+              final.callCabal2nix
+                "genvalidity-text"
+                (validity + /genvalidity-text)
+                { };
+
+            genvalidity-time =
+              final.callCabal2nix
+                "genvalidity-time"
+                (validity + /genvalidity-time)
+                { };
+
+            genvalidity-unordered-containers =
+              final.callCabal2nix
+                "genvalidity-unordered-containers"
+                (validity + /genvalidity-unordered-containers)
+                { };
+
+            genvalidity-uuid =
+              final.callCabal2nix
+                "genvalidity-uuid"
+                (validity + /genvalidity-uuid)
+                { };
+
+            genvalidity-vector =
+              final.callCabal2nix
+                "genvalidity-vector"
+                (validity + /genvalidity-vector)
+                { };
+
+            iCalendar =
+              final.callCabal2nix
+                "iCalendar"
+                iCalendar
+                { };
+
+            looper =
+              final.callCabal2nix
+                "looper"
+                (looper + /looper)
+                { };
+
+            mergeful =
+              final.callCabal2nix
+                "mergeful"
+                (mergeful + /mergeful)
+                { };
+
+            mergeful-persistent =
+              final.callCabal2nix
+                "mergeful-persistent"
+                (mergeful + /mergeful-persistent)
+                { };
+
+            nvalidity-typed-uuid =
+              final.callCabal2nix
+                "genvalidity-typed-uuid"
+                (typed-uuid + /nvalidity-typed-uuid)
+                { };
+
+            org-parser =
+              final.callCabal2nix
+                "org-parser"
+                org-parser
+                { };
+
+            ped-uuid =
+              final.callCabal2nix
+                "typed-uuid"
+                (typed-uuid + /ped-uuid)
+                { };
+
+            pretty-relative-time =
+              final.callCabal2nix
+                "pretty-relative-time"
+                pretty-relative-time
+                { };
+
+            safe-coloured-text =
+              final.callCabal2nix
+                "safe-coloured-text"
+                (safe-coloured-text + /safe-coloured-text)
+                { };
+
+            safe-coloured-text-gen =
+              final.callCabal2nix
+                "safe-coloured-text-gen"
+                (safe-coloured-text + /safe-coloured-text-gen)
+                { };
+
+            safe-coloured-text-layout =
+              final.callCabal2nix
+                "safe-coloured-text-layout"
+                (safe-coloured-text + /safe-coloured-text-layout)
+                { };
+
+            safe-coloured-text-layout-gen =
+              final.callCabal2nix
+                "safe-coloured-text-layout-gen"
+                (safe-coloured-text + /safe-coloured-text-layout-gen)
+                { };
+
+            safe-coloured-text-terminfo =
+              final.callCabal2nix
+                "safe-coloured-text-terminfo"
+                (safe-coloured-text + /safe-coloured-text-terminfo)
+                { };
+
+            sydtest =
+              final.callCabal2nix
+                "sydtest"
+                (sydtest + /sydtest)
+                { };
+
+            sydtest-aeson =
+              final.callCabal2nix
+                "sydtest-aeson"
+                (sydtest + /sydtest-aeson)
+                { };
+
+            sydtest-discover =
+              final.callCabal2nix
+                "sydtest-discover"
+                (sydtest + /sydtest-discover)
+                { };
+
+            sydtest-persistent =
+              final.callCabal2nix
+                "sydtest-persistent"
+                (sydtest + /sydtest-persistent)
+                { };
+
+            sydtest-persistent-sqlite =
+              final.callCabal2nix
+                "sydtest-persistent-sqlite"
+                (sydtest + /sydtest-persistent-sqlite)
+                { };
+
+            sydtest-servant =
+              final.callCabal2nix
+                "sydtest-servant"
+                (sydtest + /sydtest-servant)
+                { };
+
+            sydtest-wai =
+              final.callCabal2nix
+                "sydtest-wai"
+                (sydtest + /sydtest-wai)
+                { };
+
+            sydtest-yesod =
+              final.callCabal2nix
+                "sydtest-yesod"
+                (sydtest + /sydtest-yesod)
+                { };
+
+            template-haskell-reload =
+              final.callCabal2nix
+                "template-haskell-reload"
+                (template-haskell-reload + /template-haskell-reload)
+                { };
+
+            validity =
+              final.callCabal2nix
+                "validity"
+                (validity + /validity)
+                { };
+
+            validity-aeson =
+              final.callCabal2nix
+                "validity-aeson"
+                (validity + /validity-aeson)
+                { };
+
+            validity-bytestring =
+              final.callCabal2nix
+                "validity-bytestring"
+                (validity + /validity-bytestring)
+                { };
+
+            validity-containers =
+              final.callCabal2nix
+                "validity-containers"
+                (validity + /validity-containers)
+                { };
+
+            validity-path =
+              final.callCabal2nix
+                "validity-path"
+                (validity + /validity-path)
+                { };
+
+            validity-persistent =
+              final.callCabal2nix
+                "validity-persistent"
+                (validity + /validity-persistent)
+                { };
+
+            validity-primitive =
+              final.callCabal2nix
+                "validity-primitive"
+                (validity + /validity-primitive)
+                { };
+
+            validity-scientific =
+              final.callCabal2nix
+                "validity-scientific"
+                (validity + /validity-scientific)
+                { };
+
+            validity-text =
+              final.callCabal2nix
+                "validity-text"
+                (validity + /validity-text)
+                { };
+
+            validity-time =
+              final.callCabal2nix
+                "validity-time"
+                (validity + /validity-time)
+                { };
+
+            validity-unordered-containers =
+              final.callCabal2nix
+                "validity-unordered-containers"
+                (validity + /validity-unordered-containers)
+                { };
+
+            validity-uuid =
+              final.callCabal2nix
+                "validity-uuid"
+                (validity + /validity-uuid)
+                { };
+
+            validity-vector =
+              final.callCabal2nix
+                "validity-vector"
+                (validity + /validity-vector)
+                { };
+
+            yesod-autoreload =
+              final.callCabal2nix
+                "yesod-autoreload"
+                yesod-autoreload
+                { };
+
+            yesod-static-remote =
+              final.callCabal2nix
+                "yesod-static-remote"
+                yesod-static-remote
+                { };
+
+            # Smos packages
+            smos =
+              final.callCabal2nix
+                "smos" ./smos
+                { };
+
+            smos-api =
+              final.callCabal2nix
+                "smos-api" ./smos-api
+                { };
+
+            smos-api-gen =
+              final.callCabal2nix
+                "smos-api-gen" ./smos-api-gen
+                { };
+
+            smos-archive = addBuildDeps [ final.autoexporter ] (
+              final.callCabal2nix
+                "smos-archive" ./smos-archive
+                { }
+            );
+
+            smos-calendar-import =
+              final.callCabal2nix
+                "smos-calendar-import" ./smos-calendar-import
+                { };
+
+            smos-client =
+              final.callCabal2nix
+                "smos-client" ./smos-client
+                { };
+
+            smos-cursor =
+              final.callCabal2nix
+                "smos-cursor" ./smos-cursor
+                { };
+
+            smos-cursor-gen =
+              final.callCabal2nix
+                "smos-cursor-gen" ./smos-cursor-gen
+                { };
+
+            smos-data =
+              final.callCabal2nix
+                "smos-data" ./smos-data
+                { };
+
+            smos-data-gen =
+              final.callCabal2nix
+                "smos-data-gen" ./smos-data-gen
+                { };
+
+            smos-github =
+              final.callCabal2nix
+                "smos-github" ./smos-github
+                { };
+
+            smos-notify =
+              final.callCabal2nix
+                "smos-notify" ./smos-notify
+                { };
+
+            smos-query =
+              final.callCabal2nix
+                "smos-query" ./smos-query
+                { };
+
+            smos-report =
+              final.callCabal2nix
+                "smos-report" ./smos-report
+                { };
+
+            smos-report-cursor =
+              final.callCabal2nix
+                "smos-report-cursor" ./smos-report-cursor
+                { };
+
+            smos-report-cursor-gen =
+              final.callCabal2nix
+                "smos-report-cursor-gen" ./smos-report-cursor-gen
+                { };
+
+            smos-report-gen =
+              final.callCabal2nix
+                "smos-report-gen" ./smos-report-gen
+                { };
+
+            smos-scheduler =
+              final.callCabal2nix
+                "smos-scheduler" ./smos-scheduler
+                { };
+
+            smos-single =
+              final.callCabal2nix
+                "smos-single" ./smos-single
+                { };
+
+            smos-sync-client =
+              final.callCabal2nix
+                "smos-sync-client" ./smos-sync-client
+                { };
+
+            smos-sync-client-gen =
+              final.callCabal2nix
+                "smos-sync-client-gen" ./smos-sync-client-gen
+                { };
+
+            smos-web-style =
+              final.callCabal2nix
+                "smos-web-style" ./smos-web-style
+                { };
+          });
+      in
+      {
+        packages = {
+          smos-archive = haskellPackages.smos-archive;
+          smos-calendar-import = haskellPackages.smos-calendar-import;
+          smos-github = haskellPackages.smos-github;
+          smos-notify = haskellPackages.smos-notify;
+          smos-query = haskellPackages.smos-query;
+          smos-scheduler = haskellPackages.smos-scheduler;
+          smos-single = haskellPackages.smos-single;
+          smos-sync-client = haskellPackages.smos-sync-client;
+          smos = haskellPackages.smos;
+        };
+
+        defaultPackage = nixpkgs.legacyPackages.${system}.symlinkJoin {
+          name = self.packages.${system}.smos.name;
+          paths = with self.packages.${system}; [
+            smos-archive
+            smos-calendar-import
+            smos-github
+            smos-notify
+            smos-query
+            smos-scheduler
+            smos-single
+            smos-sync-client
+            smos
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
This adds a Nix flake for Smos.

Try it out: `nix run github:vapourismo/smos/feature/flake#smos`
The above requires experimental features to be enabled: `nix-command flakes`

Packages that depend on `smos-stripe-client` weren't added.

GHC 9.0.2 has been picked as per `stack.yaml`'s LTS-19.6. The dependencies are pinned via Flake inputs using the repository and revision combinations in `stack.yaml`.