### PR TITLE
nix: using lib.foldr due to deprecated lib.fold

### DIFF
--- a/nix/merge-lists-recursively.nix
+++ b/nix/merge-lists-recursively.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 attrList:
-lib.fold
+lib.foldr
   (
     x: y:
     lib.recursiveUpdate x y


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/456532