### PR TITLE
Use $EDITOR to edit entry contents

### DIFF
--- a/smos/src/Smos/Actions/Entry/Contents.hs
+++ b/smos/src/Smos/Actions/Entry/Contents.hs
@@ -19,13 +19,13 @@ module Smos.Actions.Entry.Contents
     contentsMoveToPrevWord,
     contentsMoveToBeginningOfWord,
     contentsMoveToEndOfWord,
-    contentsUseVim,
-    contentsUseEmacs,
+    contentsUseEditor,
   )
 where
 
 import Brick.Main (suspendAndResume')
 import qualified Data.ByteString as SB
+import qualified Data.Maybe as Maybe
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Lens.Micro
@@ -34,6 +34,7 @@ import Path.IO
 import Smos.Actions.Utils
 import Smos.Data
 import Smos.Types
+import System.Environment (lookupEnv)
 import System.Exit
 import System.Process
 
@@ -53,8 +54,7 @@ allContentsPlainActions =
     contentsMoveToPrevWord,
     contentsMoveToBeginningOfWord,
     contentsMoveToEndOfWord,
-    contentsUseVim,
-    contentsUseEmacs
+    contentsUseEditor
   ]
 
 allContentsUsingCharActions :: [ActionUsing Char]
@@ -200,30 +200,23 @@ contentsMoveToBeginningOfWord =
       actionDescription = "Move to the beginning of the word in the contents"
     }
 
-contentsUseVim :: Action
-contentsUseVim = contentsUseEditorAction "vim"
+contentsUseEditor :: Action
+contentsUseEditor = Action
+  { actionName = "contentsUseEditor"
+  , actionFunc = contentsEditorIntegration
+  , actionDescription = "Use $EDITOR (or nano) to edit the contents of the current entry."
+  }
 
-contentsUseEmacs :: Action
-contentsUseEmacs = contentsUseEditorAction "emacs"
-
-contentsUseEditorAction :: String -> Action
-contentsUseEditorAction command =
-  let t = T.pack command
-   in Action
-        { actionName = "contentsUse_" <> ActionName t,
-          actionFunc = contentsEditorIntegration command,
-          actionDescription = "Use " <> t <> " to edit the contents of the current entry."
-        }
-
-contentsEditorIntegration :: String -> SmosM ()
-contentsEditorIntegration command = requireUnsandboxed $
+contentsEditorIntegration :: SmosM ()
+contentsEditorIntegration = requireUnsandboxed $
   modifyEntryCursorS $ \ec -> do
+    editor <- liftIO $ Maybe.fromMaybe "nano" <$> lookupEnv "EDITOR"
     (exitCode, newBytes) <- liftEventM $
       suspendAndResume' $
         withSystemTempDir "smos-contents" $ \tdir -> do
           file <- resolveFile tdir "entry-contents"
           SB.writeFile (fromAbsFile file) (maybe "" (TE.encodeUtf8 . contentsText . rebuildContentsCursor) $ entryCursorContentsCursor ec)
-          let cp = proc command [fromAbsFile file]
+          let cp = proc editor [fromAbsFile file]
           exitCode <- withCreateProcess cp $ \_ _ _ processHandle -> do
             waitForProcess processHandle
           newBytes <- SB.readFile (fromAbsFile file)
@@ -233,7 +226,7 @@ contentsEditorIntegration command = requireUnsandboxed $
         addErrorMessage $
           T.pack $
             unlines
-              [ unwords ["Editor", show command],
+              [ unwords ["Editor", show editor],
                 unwords ["failed with exit code", show errCode]
               ]
         pure ec

--- a/smos/src/Smos/Default.hs
+++ b/smos/src/Smos/Default.hs
@@ -150,8 +150,7 @@ defaultFileKeyMap =
             exactKey KEnter entrySelectContentsAtEnd,
             exactKeyPress (KeyPress KEnter [MMeta]) entrySelectContentsAtStart,
             exactKeyPress (KeyPress (KChar 'o') [MMeta]) entrySelectContentsAtStart,
-            exactString "cv" contentsUseVim,
-            exactString "ce" contentsUseEmacs,
+            exactString "ce" contentsUseEditor,
             -- Entering tags
             exactString "gi" entrySelectTagsFromStart,
             exactString "ga" entrySelectTagsFromBack


### PR DESCRIPTION
Closes https://github.com/NorfairKing/smos/issues/298

### Disclaimer

I'll be honest, **I mostly used AI ️⚠️🥀** (_because I don't know Haskell, but I can program at a basic+ level_), but I **tried** to find and apply the most **concise**, **simple** (so as not to make many changes that could potentially break something) and **idiomatic** solution for Haskell among all the proposed solutions.

I just need this feature, so I didn't wait for others to implement it, but **tried** to make it myself.

### What has changed

The current solution takes the environment variable `$EDITOR` and uses its value as an editor to **edit the contents of the current entry** when pressing the `ce` keys (`e` stands for **editor**). If the environment variable `$EDITOR` is **unset**, then the `nano` editor, which is **pre-installed in most Linux distributions**, will be used.

That is, instead of `contentsUseVim` and `contentsUseEmacs`, the universal `contentsUseEditor` is now used.

<img width="1362" height="129" alt="menyoki_1769976279" src="https://github.com/user-attachments/assets/20f02ef4-0a2b-4101-a812-b705d3adfe78" />

---
Of course, I compiled and tested the functionality that I implemented. I have the variable `EDITOR=hx` set, so `hx` (helix) opens properly for editing, but if I run `unset EDITOR` before running **smos**, then **nano** opens.

And even if this solution won't suit (idk), it's OK, I just wanted to do at least some of the work on my part.